### PR TITLE
プロジェクト名を「zu-tech」から「zutech」に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 <img src="https://user-images.githubusercontent.com/33179078/72317233-e8d17400-36db-11ea-9630-141cf75a178e.png" alt="image" title="ZU TECH"><br><br>
 </div>
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/e793d249-10fa-4b02-96ea-0aa6540a1580/deploy-status)](https://app.netlify.com/sites/zu-tech/deploys)
-
+[![Netlify Status](https://api.netlify.com/api/v1/badges/e793d249-10fa-4b02-96ea-0aa6540a1580/deploy-status)](https://app.netlify.com/sites/zutech/deploys)
 ## App URL
-- zu-tech.netlify.com
+https://zutech.netlify.com
 
 ## ビルドとセットアップ
 

--- a/config/website.json
+++ b/config/website.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://zu-tech.netlify.com",
+  "url": "https://zutech.netlify.com",
   "title": "ZU TECH",
   "description": "こんにちは。大学院生のZuが発信する技術ブログです。フロントエンドからバックエンドの情報を紹介します。"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zu-tech",
+  "name": "zutech",
   "version": "1.0.0",
   "description": "Zu's Tech Blog",
   "author": "Kazuki Yamagata",


### PR DESCRIPTION
## 概要
ハイフンがあることでTwitterなどでリンクを載せた時に改行されてしまうため、ハイフンを消すことに決定した