### PR TITLE
タグ検索時のサムネイルが表示されない問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@nuxtjs/markdownit": "^1.2.7",
     "@nuxtjs/pwa": "^3.0.0-0",
     "contentful": "^7.12.0",
-    "fuse.js": "^5.2.3",
+    "fuse.js": "3.4.6",
     "http-server": "^0.12.1",
     "markdown-it": "^10.0.0",
     "node-sass": "^4.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4103,10 +4103,10 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-fuse.js@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-5.2.3.tgz#fdf3aa62859782b3f73ddfa57a9ca81517280c91"
-  integrity sha512-ld3AEgKtKnnXCtJavtygAb+aLlD5aVvLwTocXXBSStLA6JGFI6oMxTvumwh46N2/3gs3A7JNDu1px5F1/cq84g==
+fuse.js@3.4.6:
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.4.6.tgz#545c3411fed88bf2e27c457cab6e73e7af697a45"
+  integrity sha512-H6aJY4UpLFwxj1+5nAvufom5b2BT2v45P1MkPvdGIK8fWjQx/7o6tTT1+ALV0yawQvbmvCF0ufl2et8eJ7v7Cg==
 
 gauge@~2.7.3:
   version "2.7.4"


### PR DESCRIPTION
## 概要
fuse.jsをダウングレードすることにより、タグ検索時のサムネイルが表示されない問題を修正した。
アップデートしたことが問題だったらしいが、細かな挙動までは追えていない。